### PR TITLE
chore(goreleaser): replace archives.replacements with archives.name_template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,14 @@ builds:
       - '6'
       - '7'
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{ .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "arm" }}arm_{{ .Arm }}
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/tasks.toml
+++ b/tasks.toml
@@ -5,7 +5,14 @@ cmds = [
 
 [tasks.release]
 cmds = [
-  "goreleaser release"
+  "git tag -a v${VERSION}",
+  "git push --tags",
+  "goreleaser release --clean",
+]
+
+[tasks.release_dry]
+cmds = [
+  "goreleaser release --clean --skip-publish --skip-validate"
 ]
 
 [tasks.test]


### PR DESCRIPTION
- replace archives.replacements with archives.name_template, its deprecated
- add a task, `release_dry` to dry run releases
- add git tag bits to `release` task