### PR TITLE
chore: put release steps into script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,7 +6,7 @@ if [ -z "$version" ] || [[ "$version" =~ ^v.*$ ]]; then
   exit 1
 fi
 
-if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]$ ]]; then
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9](-.*)?$ ]]; then
   echo "Error: '$version' doesnt look like a valid semver string."
   exit 1
 fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$version" ] || [[ "$version" =~ ^v.*$ ]]; then
+  echo "ERROR: \$version must be set to a semver string without the leading 'v'."
+  exit 1
+fi
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]$ ]]; then
+  echo "Error: '$version' doesnt look like a valid semver string."
+  exit 1
+fi
+
+git tag -a v${version}
+git push --tags
+goreleaser release --clean
+

--- a/tasks.toml
+++ b/tasks.toml
@@ -5,11 +5,6 @@ cmds = [
 
 [tasks.release]
 dotenv = ".env"
-cmds = [
-  "git tag -a v${version}",
-  "git push --tags",
-  "goreleaser release --clean",
-]
 
 [tasks.release_dry]
 cmds = [


### PR DESCRIPTION
ive goofed a couple times with the version var when releasing. this moves the release steps to a script where i can do some validation before actually tagging and releasing.