### PR TITLE
feat: sign and notarized macos builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build/
 dist/
 bin/
+
+.DS_Store

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ release:
   extra_files:
     - glob: ./dist/tsk_macos_arm64.zip
       name_template: >-
-        {{ .ProjectName }}_v{{ .Version }}_Macos_{{ .Arch }}.zip
+        {{ .ProjectName }}_v{{ .Version }}_Macos_arm64.zip
     - glob: ./dist/tsk_macos_amd64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip
@@ -68,7 +68,7 @@ checksum:
   extra_files:
     - glob: dist/tsk_macos_arm64.zip
       name_template: >-
-        {{ .ProjectName }}_v{{ .Version }}_Macos_{{ .Arch }}.zip
+        {{ .ProjectName }}_v{{ .Version }}_Macos_arm64.zip
     - glob: dist/tsk_macos_amd64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,16 +1,29 @@
 before:
   hooks:
     - go mod tidy
+
+# only release linux because macos archives are built by gon and
+# included in extra_files
 release:
   prerelease: auto
+  ids:
+    - linux
+  extra_files:
+    - glob: ./dist/tsk_macos_arm64.zip
+      name_template: >-
+        {{ .ProjectName }}_v{{ .Version }}_Macos_Arm64.zip
+    - glob: ./dist/task_macos_amd64.zip
+      name_template: >-
+        {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip
+
 builds:
   - binary: tsk
+    id: linux
     main: ./cmd/tsk
     env:
       - CGO_ENABLED=0
     goos:
       - linux
-      - darwin
     goarch:
       - amd64
       - arm
@@ -23,18 +36,50 @@ builds:
         -s -w
         -X "main.version={{.Version}}"
         -X "main.commit={{.Commit}}"
+  - binary: tsk
+    id: macos
+    main: ./cmd/tsk
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - >-
+        -s -w
+        -X "main.version={{.Version}}"
+        -X "main.commit={{.Commit}}"
+    hooks:
+      post:
+        - cmd: gon gon-{{.Arch}}.hcl
+          output: true
+
 archives:
-  - name_template: >-
+  - builds:
+      - linux
+    name_template: >-
       {{ .ProjectName }}_v{{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "arm" }}arm_{{ .Arm }}
       {{- else }}{{ .Arch }}{{ end }}
+
 checksum:
-  name_template: 'checksums.txt'
+  name_template: checksums.txt
+  extra_files:
+    - glob: dist/tsk_macos_arm64.zip
+      name_template: >-
+        {{ .ProjectName }}_v{{ .Version }}_Macos_Arm64.zip
+    - glob: dist/tsk_macos_amd64.zip
+      name_template: >-
+        {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip
+
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ release:
   extra_files:
     - glob: ./dist/tsk_macos_arm64.zip
       name_template: >-
-        {{ .ProjectName }}_v{{ .Version }}_Macos_Arm64.zip
+        {{ .ProjectName }}_v{{ .Version }}_Macos_{{ .Arch }}.zip
     - glob: ./dist/tsk_macos_amd64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip
@@ -72,7 +72,7 @@ checksum:
   extra_files:
     - glob: dist/tsk_macos_arm64.zip
       name_template: >-
-        {{ .ProjectName }}_v{{ .Version }}_Macos_Arm64.zip
+        {{ .ProjectName }}_v{{ .Version }}_Macos_{{ .Arch }}.zip
     - glob: dist/tsk_macos_amd64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ release:
     - glob: ./dist/tsk_macos_arm64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_Arm64.zip
-    - glob: ./dist/task_macos_amd64.zip
+    - glob: ./dist/tsk_macos_amd64.zip
       name_template: >-
         {{ .ProjectName }}_v{{ .Version }}_Macos_x86_64.zip
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,12 +2,8 @@ before:
   hooks:
     - go mod tidy
 
-# only release linux because macos archives are built by gon and
-# included in extra_files
 release:
   prerelease: auto
-  ids:
-    - linux
   extra_files:
     - glob: ./dist/tsk_macos_arm64.zip
       name_template: >-

--- a/gon-amd64.hcl
+++ b/gon-amd64.hcl
@@ -1,0 +1,24 @@
+apple_id {
+  password = "@env:AC_PASSWORD"
+}
+
+bundle_id = "com.notnmeyer.tsk"
+
+source = [
+  "./dist/macos_darwin_amd64_v1/tsk",
+]
+
+sign {
+  application_identity = "Developer ID Application: Nathan Meyer"
+}
+
+# https://github.com/mitchellh/gon/issues/64
+# dmg {
+#   output_path = "./dist/tsk.dmg"
+#   volume_name = "tsk"
+# }
+
+zip {
+  output_path = "./dist/tsk_macos_amd64.zip"
+}
+

--- a/gon-arm64.hcl
+++ b/gon-arm64.hcl
@@ -1,0 +1,24 @@
+apple_id {
+  password = "@env:AC_PASSWORD"
+}
+
+bundle_id = "com.notnmeyer.tsk"
+
+source = [
+  "./dist/macos_darwin_arm64/tsk",
+]
+
+sign {
+  application_identity = "Developer ID Application: Nathan Meyer"
+}
+
+# https://github.com/mitchellh/gon/issues/64
+# dmg {
+#   output_path = "./dist/tsk.dmg"
+#   volume_name = "tsk"
+# }
+
+zip {
+  output_path = "./dist/tsk_macos_arm64.zip"
+}
+

--- a/tasks.toml
+++ b/tasks.toml
@@ -14,7 +14,7 @@ dotenv = ".env"
 [tasks.release_dry]
 dotenv = ".env"
 cmds = [
-  "goreleaser release --clean --skip-publish --skip-validate --skip-sign"
+  "goreleaser release --clean --skip-publish --skip-validate"
 ]
 
 [tasks.test]

--- a/tasks.toml
+++ b/tasks.toml
@@ -3,12 +3,18 @@ cmds = [
   "goreleaser build --single-target --snapshot --clean --output bin/tsk"
 ]
 
+[tasks.clean]
+cmds = [
+  "rm -rf ./dist/*"
+]
+
 [tasks.release]
 dotenv = ".env"
 
 [tasks.release_dry]
+dotenv = ".env"
 cmds = [
-  "goreleaser release --clean --skip-publish --skip-validate"
+  "goreleaser release --clean --skip-publish --skip-validate --skip-sign"
 ]
 
 [tasks.test]
@@ -19,3 +25,10 @@ cmds = ["go mod tidy"]
 
 [tasks.install_release]
 env = { version = "0.2.0", platform = "Darwin", arch = "arm64" }
+
+[tasks.sign]
+dotenv = ".env"
+cmds = [
+  "gon gon-arm64.hcl",
+  "gon gon-amd64.hcl",
+]


### PR DESCRIPTION
signs and notarizes macOS builds. because im building locally for now and gon has issues producing dmg's for apple silicon, only zips for macOS are available.

notarized zips dont support stapling and require internet access to verify the notarization on the first run. 

closes https://github.com/notnmeyer/tsk/issues/22