### PR TITLE
feat: "pure" tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ tsk loads environment variables and merges them with the precendence listed belo
 1. `tasks.<task_name>.env`
 1. the parent process, e.g., `MY_VAR=hey tsk ...`
 1. `tasks.<task_name>.dotenv`
+
+#### "pure" tasks
+
+setting `pure = true` on a task will prevent the parent process's environment from being inherited. Similarly, the CLI argument `--pure` will prevent _any_ task from inheriting the parent's env. the only exceptions are `$USER` and `$HOME`, which are always inherited.

--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -12,16 +12,16 @@ var version, commit string
 
 func main() {
 	var (
-		displayVersion     bool
-		listTasks          bool
-		noInheritParentEnv bool
-		taskFile           string
-		tasks              []string
+		displayVersion bool
+		listTasks      bool
+		pure           bool
+		taskFile       string
+		tasks          []string
 	)
 
 	flag.BoolVarP(&displayVersion, "version", "V", false, "display tsk version")
 	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
-	flag.BoolVarP(&noInheritParentEnv, "pure", "", false, "don't inherit the parent env")
+	flag.BoolVarP(&pure, "pure", "", false, "don't inherit the parent env")
 	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")
 	flag.Parse()
 	tasks = flag.Args()
@@ -49,7 +49,7 @@ func main() {
 		return
 	}
 
-	if noInheritParentEnv {
+	if pure {
 		for name, task := range exec.Config.Tasks {
 			task.Pure = true
 			exec.Config.Tasks[name] = task

--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -12,15 +12,17 @@ var version, commit string
 
 func main() {
 	var (
-		listTasks      bool
-		taskFile       string
-		tasks          []string
-		displayVersion bool
+		displayVersion     bool
+		listTasks          bool
+		noInheritParentEnv bool
+		taskFile           string
+		tasks              []string
 	)
 
-	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
-	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")
 	flag.BoolVarP(&displayVersion, "version", "V", false, "display tsk version")
+	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
+	flag.BoolVarP(&noInheritParentEnv, "pure", "", false, "don't inherit the parent env")
+	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")
 	flag.Parse()
 	tasks = flag.Args()
 
@@ -45,6 +47,13 @@ func main() {
 	if listTasks {
 		exec.ListTasksFromTaskFile(exec.Config)
 		return
+	}
+
+	if noInheritParentEnv {
+		for name, task := range exec.Config.Tasks {
+			task.Pure = true
+			exec.Config.Tasks[name] = task
+		}
 	}
 
 	// verify the tasks at the cli exist


### PR DESCRIPTION
a "pure" task does not inherit the parent process's environment, with the exception of `$USER` and `$HOME`. a task can be made pure by setting `pure = true` in the task definition, or all tasks can be made pure by using the CLI argument `--pure`.