### PR TITLE
feat: add `--filter` for filtering `--list` output

### DIFF
--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/notnmeyer/tsk/internal/task"
 	flag "github.com/spf13/pflag"
@@ -18,6 +19,7 @@ func init() {
 func main() {
 	var (
 		displayVersion bool
+		filter         string
 		listTasks      bool
 		pure           bool
 		taskFile       string
@@ -25,6 +27,7 @@ func main() {
 	)
 
 	flag.BoolVarP(&displayVersion, "version", "V", false, "display tsk version")
+	flag.StringVarP(&filter, "filter", "", ".*", "regex filter for --list")
 	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
 	flag.BoolVarP(&pure, "pure", "", false, "don't inherit the parent env")
 	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")
@@ -50,7 +53,7 @@ func main() {
 	}
 
 	if listTasks {
-		exec.ListTasksFromTaskFile(exec.Config)
+		exec.ListTasksFromTaskFile(regexp.MustCompile(filter))
 		return
 	}
 

--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -30,7 +30,7 @@ func main() {
 	flag.StringVarP(&filter, "filter", "F", ".*", "regex filter for --list")
 	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
 	flag.BoolVarP(&pure, "pure", "", false, "don't inherit the parent env")
-	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")
+	flag.StringVarP(&taskFile, "file", "f", "tasks.toml", "taskfile to use")
 	flag.Parse()
 	tasks = flag.Args()
 

--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -27,7 +27,7 @@ func main() {
 	)
 
 	flag.BoolVarP(&displayVersion, "version", "V", false, "display tsk version")
-	flag.StringVarP(&filter, "filter", "", ".*", "regex filter for --list")
+	flag.StringVarP(&filter, "filter", "F", ".*", "regex filter for --list")
 	flag.BoolVarP(&listTasks, "list", "l", false, "list tasks")
 	flag.BoolVarP(&pure, "pure", "", false, "don't inherit the parent env")
 	flag.StringVarP(&taskFile, "file", "f", "", "taskfile to use")

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -164,15 +164,18 @@ func (exec *Executor) runCommand(cmd string, dir string, env []string) error {
 }
 
 func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp) {
-	filteredTasks := make(map[string]Task)
+	tasks := filterTasks(&exec.Config.Tasks, regex)
+	toml.NewEncoder(os.Stdout).Encode(tasks)
+}
 
-	for k, v := range exec.Config.Tasks {
+func filterTasks(tasks *map[string]Task, regex *regexp.Regexp) map[string]Task {
+	filtered := make(map[string]Task)
+	for k, v := range *tasks {
 		if regex.MatchString(k) {
-			filteredTasks[k] = v
+			filtered[k] = v
 		}
 	}
-
-	toml.NewEncoder(os.Stdout).Encode(filteredTasks)
+	return filtered
 }
 
 func NewTaskConfig(taskFile string) (*Config, error) {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -162,8 +163,16 @@ func (exec *Executor) runCommand(cmd string, dir string, env []string) error {
 	return nil
 }
 
-func (exec *Executor) ListTasksFromTaskFile(config *Config) {
-	toml.NewEncoder(os.Stdout).Encode(config.Tasks)
+func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp) {
+	filteredTasks := make(map[string]Task)
+
+	for k, v := range exec.Config.Tasks {
+		if regex.MatchString(k) {
+			filteredTasks[k] = v
+		}
+	}
+
+	toml.NewEncoder(os.Stdout).Encode(filteredTasks)
 }
 
 func NewTaskConfig(taskFile string) (*Config, error) {

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -273,3 +273,23 @@ func TestGlobalEnvInheritance(t *testing.T) {
 		t.Errorf("Expected '%s', got %s", expected, out.String())
 	}
 }
+
+func TestFilterTasks(t *testing.T) {
+	var (
+		tasks = map[string]Task{
+			"foo": {},
+			"bar": {},
+		}
+		expectedKey = "foo"
+		re          = regexp.MustCompile(expectedKey)
+		result      = filterTasks(&tasks, re)
+	)
+
+	if len(result) != 1 {
+		t.Errorf("Expected `len(res) == 1`, got %d", len(result))
+	}
+
+	if _, ok := result[expectedKey]; !ok {
+		t.Errorf("Expected key %s to exist", expectedKey)
+	}
+}


### PR DESCRIPTION
allow filtering `--list` output with `--filter`,

```
➜ tsk -f examples/tasks.toml --list --filter '.*\d
[setup1]
  Cmds = ["sleep 1", "echo 'doing setup1...'"]
  Dir = ""
  DotEnv = ""
  Pure = false

[setup2]
  Cmds = ["echo 'doing setup2...'"]
  Dir = ""
  DotEnv = ""
  Pure = false

[setup3]
  Cmds = ["echo 'doing setup3...'"]
  Dir = ""
  DotEnv = ""
  Pure = false

[setup4]
  Cmds = ["echo 'doing setup4...'"]
  Deps = [["setup2"]]
  Dir = ""
  DotEnv = ""
  Pure = false
```