### PR TITLE
feat: positional templating

### DIFF
--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -33,7 +33,13 @@ func main() {
 	flag.BoolVarP(&opts.pure, "pure", "", false, "don't inherit the parent env")
 	flag.StringVarP(&opts.taskFile, "file", "f", "tasks.toml", "taskfile to use")
 	flag.Parse()
-	opts.tasks = flag.Args()
+
+	if flag.CommandLine.ArgsLenAtDash() > 0 {
+		// exclude any arguments after after "--". these aren't task names
+		opts.tasks = flag.Args()[:flag.CommandLine.ArgsLenAtDash()]
+	} else {
+		opts.tasks = flag.Args()
+	}
 
 	if opts.displayVersion {
 		fmt.Printf("tsk v%s, git:%s\n", version, commit)

--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/notnmeyer/tsk/internal/task"
 	flag "github.com/spf13/pflag"
@@ -12,6 +13,7 @@ import (
 var version, commit string
 
 type Options struct {
+	cliArgs        string
 	displayVersion bool
 	filter         string
 	listTasks      bool
@@ -35,8 +37,10 @@ func main() {
 	flag.Parse()
 
 	if flag.CommandLine.ArgsLenAtDash() > 0 {
-		// exclude any arguments after after "--". these aren't task names
+		// args before "--" are tasks to run
 		opts.tasks = flag.Args()[:flag.CommandLine.ArgsLenAtDash()]
+		// args after "--" are optionally templated into the taskfile
+		opts.cliArgs = strings.Join(flag.Args()[flag.CommandLine.ArgsLenAtDash():], " ")
 	} else {
 		opts.tasks = flag.Args()
 	}
@@ -47,7 +51,7 @@ func main() {
 	}
 
 	// cfg is the parsed task file
-	cfg, err := task.NewTaskConfig(opts.taskFile)
+	cfg, err := task.NewTaskConfig(opts.taskFile, opts.cliArgs)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/tasks.toml
+++ b/examples/tasks.toml
@@ -65,6 +65,11 @@ cmds = [
   'echo "$BLAH"'
 ]
 
+[tasks.template]
+cmds = [
+  "echo {{.CLI_ARGS}}"
+]
+
 # tasks used to demonstrate features above
 [tasks.setup1]
 cmds = ["sleep 1", "echo 'doing setup1...'"]

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -178,7 +178,7 @@ func filterTasks(tasks *map[string]Task, regex *regexp.Regexp) map[string]Task {
 	return filtered
 }
 
-func NewTaskConfig(taskFile string) (*Config, error) {
+func NewTaskConfig(taskFile, cliArgs string) (*Config, error) {
 	var err error
 	if taskFile == "" {
 		dir, _ := os.Getwd()
@@ -189,7 +189,7 @@ func NewTaskConfig(taskFile string) (*Config, error) {
 	}
 
 	// render the task file as a template
-	rendered, err := render(taskFile)
+	rendered, err := render(taskFile, cliArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -188,9 +188,15 @@ func NewTaskConfig(taskFile string) (*Config, error) {
 		}
 	}
 
+	// render the task file as a template
+	rendered, err := render(taskFile)
+	if err != nil {
+		return nil, err
+	}
+
 	// parse the task file
 	var config Config
-	if _, err := toml.DecodeFile(taskFile, &config); err != nil {
+	if _, err := toml.Decode(rendered.String(), &config); err != nil {
 		return nil, err
 	}
 

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -293,3 +293,21 @@ func TestFilterTasks(t *testing.T) {
 		t.Errorf("Expected key %s to exist", expectedKey)
 	}
 }
+
+// templating of .CLI_ARGS
+func TestTemplates(t *testing.T) {
+	// this doesnt work. maybe we should parse the extra args into the config struct initially?
+	os.Args = append(os.Args, "-- foobar")
+
+	wd, _ := os.Getwd()
+	path, _ := findTaskFile(wd, "tasks.toml")
+	config, _ := NewTaskConfig(path)
+	out := new(bytes.Buffer)
+	exec := Executor{
+		Stdout: out,
+	}
+	exec.RunTasks(config, &[]string{"template"})
+	if out.String() != "foobar" {
+		t.Errorf("Expected '%s', got %s", "foobar", out.String())
+	}
+}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -174,8 +174,11 @@ func TestFindTaskFile(t *testing.T) {
 
 // test .env file is loaded
 func TestDotEnv(t *testing.T) {
-	var taskFile string
-	config, err := NewTaskConfig(taskFile)
+	var (
+		taskFile string
+		cliArgs  string
+	)
+	config, err := NewTaskConfig(taskFile, cliArgs)
 	if err != nil {
 		panic(err)
 	}
@@ -294,20 +297,20 @@ func TestFilterTasks(t *testing.T) {
 	}
 }
 
-// templating of .CLI_ARGS
+// CLI_ARGS template
 func TestTemplates(t *testing.T) {
-	// this doesnt work. maybe we should parse the extra args into the config struct initially?
-	os.Args = append(os.Args, "-- foobar")
-
+	cliArgs := "foobar"
+	expected := regexp.MustCompile(cliArgs)
 	wd, _ := os.Getwd()
 	path, _ := findTaskFile(wd, "tasks.toml")
-	config, _ := NewTaskConfig(path)
+	config, _ := NewTaskConfig(path, cliArgs)
 	out := new(bytes.Buffer)
 	exec := Executor{
 		Stdout: out,
 	}
+
 	exec.RunTasks(config, &[]string{"template"})
-	if out.String() != "foobar" {
-		t.Errorf("Expected '%s', got %s", "foobar", out.String())
+	if !expected.Match(out.Bytes()) {
+		t.Errorf("Expected '%s' to match '%s'", cliArgs, out.String())
 	}
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -174,10 +174,8 @@ func TestFindTaskFile(t *testing.T) {
 
 // test .env file is loaded
 func TestDotEnv(t *testing.T) {
-	var (
-		taskFile string
-		cliArgs  string
-	)
+	var taskFile, cliArgs string
+
 	config, err := NewTaskConfig(taskFile, cliArgs)
 	if err != nil {
 		panic(err)

--- a/internal/task/util.go
+++ b/internal/task/util.go
@@ -1,10 +1,14 @@
 package task
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/joho/godotenv"
-	// "path/filepath"
+	"os"
 	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/joho/godotenv"
 )
 
 func alphabetizeTaskList(t *map[string]Task) *[]string {
@@ -40,4 +44,38 @@ func appendDotEnvToEnv(env []string, dotenv string) ([]string, error) {
 	}
 	env = append(env, ConvertEnvToStringSlice(additionalEnv)...)
 	return env, nil
+}
+
+func render(file string) (*bytes.Buffer, error) {
+	tmpl, err := template.ParseFiles(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var renderedBuffer bytes.Buffer
+
+	// TODO: how and where template values come from
+	vals := make(map[string]string)
+
+	var cliArgs []string
+	if FindIndex(os.Args) > 0 {
+		cliArgs = os.Args[FindIndex(os.Args)+1:]
+	}
+
+	vals["CLI_ARGS"] = strings.Join(cliArgs, " ")
+
+	if err := tmpl.Execute(&renderedBuffer, vals); err != nil {
+		return nil, err
+	}
+
+	return &renderedBuffer, nil
+}
+
+func FindIndex(args []string) int {
+	for i, arg := range args {
+		if arg == "--" {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/task/util.go
+++ b/internal/task/util.go
@@ -3,13 +3,15 @@ package task
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"sort"
-	"strings"
 	"text/template"
 
 	"github.com/joho/godotenv"
 )
+
+type Vals struct {
+	CLI_ARGS string
+}
 
 func alphabetizeTaskList(t *map[string]Task) *[]string {
 	var taskNames []string
@@ -46,36 +48,16 @@ func appendDotEnvToEnv(env []string, dotenv string) ([]string, error) {
 	return env, nil
 }
 
-func render(file string) (*bytes.Buffer, error) {
+func render(file, cliArgs string) (*bytes.Buffer, error) {
 	tmpl, err := template.ParseFiles(file)
 	if err != nil {
 		return nil, err
 	}
 
 	var renderedBuffer bytes.Buffer
-
-	// TODO: how and where template values come from
-	vals := make(map[string]string)
-
-	var cliArgs []string
-	if FindIndex(os.Args) > 0 {
-		cliArgs = os.Args[FindIndex(os.Args)+1:]
-	}
-
-	vals["CLI_ARGS"] = strings.Join(cliArgs, " ")
-
-	if err := tmpl.Execute(&renderedBuffer, vals); err != nil {
+	if err := tmpl.Execute(&renderedBuffer, &Vals{CLI_ARGS: cliArgs}); err != nil {
 		return nil, err
 	}
 
 	return &renderedBuffer, nil
-}
-
-func FindIndex(args []string) int {
-	for i, arg := range args {
-		if arg == "--" {
-			return i
-		}
-	}
-	return -1
 }

--- a/tasks.toml
+++ b/tasks.toml
@@ -18,7 +18,7 @@ cmds = [
 ]
 
 [tasks.test]
-cmds = ["go test ./..."]
+cmds = ["go test ./... {{.CLI_ARGS}}"]
 
 [tasks.deps]
 cmds = ["go mod tidy"]


### PR DESCRIPTION
adds support for a specific template use-case. anything supplied after `--` when invoking `tsk` can be used in a tasks.toml file via the .CLI_ARGS variable. this is ~stolen from~ inspired by how task does it.

this is useful for wrapping commands while allowing additional arguments to be supplied.
 
```shell
# [tasks.template]
# cmds = ["echo {{.CLI_ARGS}}"]

➜ tsk -f examples/tasks.toml template -- choo choo
choo choo
```

a more practical example,
```shell
# [tasks.test]
# cmds = ["go test ./... {{.CLI_ARGS}}"]

➜ bin/tsk test --list --filter test -- --race
[test]
  Cmds = ["go test ./... --race"]
  Dir = ""
  DotEnv = ""
  Pure = false
```

closes https://github.com/notnmeyer/tsk/issues/27