### PR TITLE
feat: sigh, sign with codesign

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,10 @@ builds:
         -s -w
         -X "main.version={{.Version}}"
         -X "main.commit={{.Commit}}"
+    hooks:
+      post:
+        - cmd: codesign -s {{ .Env.CODESIGN_IDENTITY }} {{ .Path }}
+          output: true
 
 archives:
   - builds:


### PR DESCRIPTION
I couldn't run the binaries produced for v0.6.0 when downloaded, but they worked fine when built locally. looks like I still need to sign them. easy enough.