### PR TITLE
chore: remove exec handler

### DIFF
--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/BurntSushi/toml"
 	"mvdan.cc/sh/v3/expand"
@@ -148,7 +147,6 @@ func (exec *Executor) runCommand(cmd string, dir string, env []string) error {
 	r, err := interp.New(
 		interp.Params("-e"),
 		interp.Env(expand.ListEnviron(env...)),
-		interp.ExecHandler(interp.DefaultExecHandler(15*time.Second)),
 		interp.OpenHandler(interp.DefaultOpenHandler()),
 		interp.StdIO(exec.Stdin, exec.Stdout, exec.Stderr),
 		interp.Dir(dir),


### PR DESCRIPTION
i misunderstood this when i added it. i was thinking this was an timeout for the command being run, which is isnt. i dont think i ever bothered testing if it did what i thought. i went to make this configurable today and realized my mistake. i'm just going to remove it.