### PR TITLE
(fix): help output

### DIFF
--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -10,7 +10,10 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-var version, commit string
+var (
+	version, commit string
+	help            bool
+)
 
 type Options struct {
 	cliArgs        string
@@ -36,7 +39,15 @@ func main() {
 	flag.BoolVar(&opts.init, "init", false, "create a tasks.toml file in $PWD")
 	flag.BoolVarP(&opts.pure, "pure", "", false, "don't inherit the parent env")
 	flag.StringVarP(&opts.taskFile, "file", "f", "tasks.toml", "taskfile to use")
+	flag.BoolVarP(&help, "help", "h", false, "")
 	flag.Parse()
+
+	if help {
+		fmt.Printf("Usage: %s [options]\n", os.Args[0])
+		fmt.Println("Options:")
+		flag.PrintDefaults()
+		os.Exit(0)
+	}
 
 	if opts.init {
 		if err := task.InitTaskfile(); err != nil {


### PR DESCRIPTION
fixes the pflag error when requesting `--help`:

```
➜ tsk --help
...
pflag: help requested
```

`pflag: help requested` is an error displayed when help is requested but no help flag is defined.

with a `help` flag defined:

```
➜ tsk run -- --help
Usage: /var/folders/qm/fvys1tr11b7130r0zbbbzpx00000gn/T/go-build3156137366/b001/exe/tsk [options]
Options:
  -f, --file string     taskfile to use (default "tasks.toml")
  -F, --filter string   regex filter for --list (default ".*")
  -h, --help
      --init            create a tasks.toml file in $PWD
  -l, --list            list tasks
      --pure            don't inherit the parent env
  -V, --version         display tsk version
```