### PR TITLE
feat: list output as markdown

### DIFF
--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -69,13 +69,9 @@ func main() {
 		return
 	}
 
-	if opts.output != string(defaultOutputFormat) {
-		switch opts.output {
-		case string(output.Text), string(output.Markdown):
-		default:
-			fmt.Printf("--output must one of: %s, %s\n", string(output.Text), string(output.Markdown))
-			os.Exit(1)
-		}
+	if !output.IsValid(opts.output) {
+		fmt.Printf("--output must one of: %s\n", output.String())
+		os.Exit(1)
 	}
 
 	// check if there are args passed after "--".

--- a/internal/outputformat/outputformat.go
+++ b/internal/outputformat/outputformat.go
@@ -1,8 +1,25 @@
 package outputformat
 
+import (
+	"fmt"
+)
+
 type OutputFormat string
 
 const (
-	Text     OutputFormat = "text"
 	Markdown OutputFormat = "md"
+	Text     OutputFormat = "text"
+	TOML     OutputFormat = "toml"
 )
+
+func String() string {
+	return fmt.Sprintf("%s, %s, %s", string(Markdown), string(Text), string(TOML))
+}
+
+func IsValid(format string) bool {
+	switch format {
+	case string(Markdown), string(Text), string(TOML):
+		return true
+	}
+	return false
+}

--- a/internal/outputformat/outputformat.go
+++ b/internal/outputformat/outputformat.go
@@ -1,0 +1,8 @@
+package outputformat
+
+type OutputFormat string
+
+const (
+	Text     OutputFormat = "text"
+	Markdown OutputFormat = "md"
+)

--- a/internal/outputformat/outputformat_test.go
+++ b/internal/outputformat/outputformat_test.go
@@ -1,0 +1,17 @@
+package outputformat
+
+import (
+	"testing"
+)
+
+func TestIsValid(t *testing.T) {
+	want, got := true, IsValid("toml")
+	if want != got {
+		t.Errorf("got %t, wanted %t\n", got, want)
+	}
+
+	want, got = false, IsValid("XML")
+	if want != got {
+		t.Errorf("got %t, wanted %t\n", got, want)
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 
+	output "github.com/notnmeyer/tsk/internal/outputformat"
+
 	"github.com/BurntSushi/toml"
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
@@ -57,6 +59,13 @@ func (c *Config) CompileEnv() ([]string, error) {
 	}
 
 	return env, nil
+}
+
+func (t *Task) HasCmds() bool {
+	if len(t.Cmds) > 0 {
+		return true
+	}
+	return false
 }
 
 func (t *Task) CompileEnv(env []string) ([]string, error) {
@@ -167,58 +176,72 @@ func (exec *Executor) runCommand(cmd string, dir string, env []string) error {
 	return nil
 }
 
-func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp) {
+func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp, format output.OutputFormat) {
 	tasks := filterTasks(&exec.Config.Tasks, regex)
-
-	// gaaaah, i like the end result but i hate this
 	indent := "  "
-	for name, t := range tasks {
-		// name
-		fmt.Printf("%s:\n", name)
 
-		// description
-		if t.Description != "" {
-			fmt.Printf("%sdescription:\n", indent)
-			trimmed := strings.TrimSpace(t.Description)
-			for _, line := range strings.Split(trimmed, "\n") {
-				fmt.Printf("%s%s\n", strings.Repeat(indent, 2), line)
+	switch format {
+	case output.Markdown:
+		for name, t := range tasks {
+			fmt.Printf("## %s\n", name)
+			if len(t.Cmds) > 0 {
+				for _, cmd := range t.Cmds {
+					fmt.Printf("%s- %s\n", indent, cmd)
+				}
+			} else {
+				fmt.Printf("%s- %s/%s\n", indent, exec.Config.ScriptDir, name)
 			}
 		}
+	case output.Text:
+		// gaaaah, i like the end result but i hate this
+		for name, t := range tasks {
+			// name
+			fmt.Printf("%s:\n", name)
 
-		// deps
-		if len(t.Deps) > 0 {
-			fmt.Printf("%sdeps:\n", indent)
-			for _, dep := range t.Deps {
-				fmt.Printf("%s%v\n", indent+indent, dep)
+			// description
+			if t.Description != "" {
+				fmt.Printf("%sdescription:\n", indent)
+				trimmed := strings.TrimSpace(t.Description)
+				for _, line := range strings.Split(trimmed, "\n") {
+					fmt.Printf("%s%s\n", strings.Repeat(indent, 2), line)
+				}
 			}
-		}
 
-		// cmds
-		if len(t.Cmds) > 0 {
+			// deps
+			if len(t.Deps) > 0 {
+				fmt.Printf("%sdeps:\n", indent)
+				for _, dep := range t.Deps {
+					fmt.Printf("%s%v\n", indent+indent, dep)
+				}
+			}
+
+			// cmds
 			fmt.Printf("%scommands:\n", indent)
-			for _, cmd := range t.Cmds {
-				fmt.Printf("%s\n", indent+indent+cmd)
+			if len(t.Cmds) > 0 {
+				for _, cmd := range t.Cmds {
+					fmt.Printf("%s\n", indent+indent+cmd)
+				}
+			} else {
+				fmt.Printf("%s%s/%s\n", indent+indent, exec.Config.ScriptDir, name)
 			}
-		} else {
-			fmt.Printf("%s# will run `%s/%s`\n", indent, exec.Config.ScriptDir, name)
-		}
 
-		// dir
-		if t.Dir != "" {
-			fmt.Printf("%sdir: %s\n", indent, t.Dir)
-		}
+			// dir
+			if t.Dir != "" {
+				fmt.Printf("%sdir: %s\n", indent, t.Dir)
+			}
 
-		// dotenv
-		if t.DotEnv != "" {
-			fmt.Printf("%sdotenv: %s\n", indent, t.DotEnv)
-		}
+			// dotenv
+			if t.DotEnv != "" {
+				fmt.Printf("%sdotenv: %s\n", indent, t.DotEnv)
+			}
 
-		// pure
-		if t.Pure == true {
-			fmt.Printf("%spure: %t\n", indent, t.Pure)
-		}
+			// pure
+			if t.Pure == true {
+				fmt.Printf("%spure: %t\n", indent, t.Pure)
+			}
 
-		fmt.Println("")
+			fmt.Println("")
+		}
 	}
 
 	// pure toml representation. simple but includes blank task attributes.

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -61,13 +61,6 @@ func (c *Config) CompileEnv() ([]string, error) {
 	return env, nil
 }
 
-func (t *Task) HasCmds() bool {
-	if len(t.Cmds) > 0 {
-		return true
-	}
-	return false
-}
-
 func (t *Task) CompileEnv(env []string) ([]string, error) {
 	env = append(env, ConvertEnvToStringSlice(t.Env)...)
 
@@ -192,8 +185,9 @@ func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp, format output.
 				fmt.Printf("%s- %s/%s\n", indent, exec.Config.ScriptDir, name)
 			}
 		}
+	case output.TOML:
+		toml.NewEncoder(os.Stdout).Encode(tasks)
 	case output.Text:
-		// gaaaah, i like the end result but i hate this
 		for name, t := range tasks {
 			// name
 			fmt.Printf("%s:\n", name)
@@ -243,9 +237,6 @@ func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp, format output.
 			fmt.Println("")
 		}
 	}
-
-	// pure toml representation. simple but includes blank task attributes.
-	// toml.NewEncoder(os.Stdout).Encode(tasks)
 }
 
 func filterTasks(tasks *map[string]Task, regex *regexp.Regexp) map[string]Task {


### PR DESCRIPTION
- adds an `--output` option that can be used with `--list`
- `--output` accepts:
    - "text" (the existing format)
    - "md" for a streamlined markdown output
    - "toml"