### PR TITLE
fix: dont run goreleaser in release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ see `examples/tasks.toml` for complete usage and configuration reference.
 ## docs
 
 https://notnmeyer.github.io/tsk-docs/
+
+## release
+
+tag a new release with, `env version=0.0.0 tsk release`, and let GHA do it its thing.

--- a/tsk/release
+++ b/tsk/release
@@ -13,5 +13,5 @@ fi
 
 git tag -a v${version}
 git push --tags
-goreleaser release --clean
 
+# GHA will run goreleaser


### PR DESCRIPTION
goreleaser runs in GHA. the release script should just push a tag and let GHA do the rest.