### PR TITLE
feat: add CLI_ARGS placeholder in list output

### DIFF
--- a/cmd/tsk/tsk.go
+++ b/cmd/tsk/tsk.go
@@ -85,7 +85,7 @@ func main() {
 	}
 
 	// cfg is the parsed task file
-	cfg, err := task.NewTaskConfig(opts.taskFile, opts.cliArgs)
+	cfg, err := task.NewTaskConfig(opts.taskFile, opts.cliArgs, opts.listTasks)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -249,7 +249,7 @@ func filterTasks(tasks *map[string]Task, regex *regexp.Regexp) map[string]Task {
 	return filtered
 }
 
-func NewTaskConfig(taskFile, cliArgs string) (*Config, error) {
+func NewTaskConfig(taskFile, cliArgs string, listTasks bool) (*Config, error) {
 	var err error
 	if taskFile == "" {
 		dir, _ := os.Getwd()
@@ -260,7 +260,7 @@ func NewTaskConfig(taskFile, cliArgs string) (*Config, error) {
 	}
 
 	// render the task file as a template
-	rendered, err := render(taskFile, cliArgs)
+	rendered, err := render(taskFile, cliArgs, listTasks)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -176,7 +176,7 @@ func TestFindTaskFile(t *testing.T) {
 func TestDotEnv(t *testing.T) {
 	var taskFile, cliArgs string
 
-	config, err := NewTaskConfig(taskFile, cliArgs)
+	config, err := NewTaskConfig(taskFile, cliArgs, false)
 	if err != nil {
 		panic(err)
 	}
@@ -301,7 +301,7 @@ func TestTemplates(t *testing.T) {
 	expected := regexp.MustCompile(cliArgs)
 	wd, _ := os.Getwd()
 	path, _ := findTaskFile(wd, "tasks.toml")
-	config, _ := NewTaskConfig(path, cliArgs)
+	config, _ := NewTaskConfig(path, cliArgs, false)
 	out := new(bytes.Buffer)
 	exec := Executor{
 		Stdout: out,
@@ -310,5 +310,24 @@ func TestTemplates(t *testing.T) {
 	exec.RunTasks(config, &[]string{"template"})
 	if !expected.Match(out.Bytes()) {
 		t.Errorf("Expected '%s' to match '%s'", cliArgs, out.String())
+	}
+}
+
+// when building --list output for tasks that use CLI_ARGS test that placeholder
+// text is inserted when CLI_ARGS arent provided
+func TestTemplatesWithPlaceholders(t *testing.T) {
+	placeholder := "{{.CLI_ARGS}}"
+	expected := regexp.MustCompile(placeholder)
+	wd, _ := os.Getwd()
+	path, _ := findTaskFile(wd, "tasks.toml")
+	config, _ := NewTaskConfig(path, "", true)
+	out := new(bytes.Buffer)
+	exec := Executor{
+		Stdout: out,
+	}
+
+	exec.RunTasks(config, &[]string{"template"})
+	if !expected.Match(out.Bytes()) {
+		t.Errorf("Expected '%s' to match '%s'", placeholder, out.String())
 	}
 }

--- a/internal/task/util.go
+++ b/internal/task/util.go
@@ -56,7 +56,7 @@ func render(file, cliArgs string, cliArgsPlaceholder bool) (*bytes.Buffer, error
 
 	// insert a placeholder value for cliArgs for display purposes
 	if cliArgsPlaceholder && cliArgs == "" {
-		cliArgs = "<args>"
+		cliArgs = "{{.CLI_ARGS}}"
 	}
 
 	var renderedBuffer bytes.Buffer

--- a/internal/task/util.go
+++ b/internal/task/util.go
@@ -48,10 +48,15 @@ func appendDotEnvToEnv(env []string, dotenv string) ([]string, error) {
 	return env, nil
 }
 
-func render(file, cliArgs string) (*bytes.Buffer, error) {
+func render(file, cliArgs string, cliArgsPlaceholder bool) (*bytes.Buffer, error) {
 	tmpl, err := template.ParseFiles(file)
 	if err != nil {
 		return nil, err
+	}
+
+	// insert a placeholder value for cliArgs for display purposes
+	if cliArgsPlaceholder && cliArgs == "" {
+		cliArgs = "<args>"
 	}
 
 	var renderedBuffer bytes.Buffer


### PR DESCRIPTION
in the `--list` output when a task uses CLI_ARGS but args are not provided insert a placeholder.

for example,
```
➜ tsk --list -f examples/tasks.toml -F template
template:
  commands:
    echo {{.CLI_ARGS}}
```

but if args are provided, use them,
```
➜ tsk run -- --list -f examples/tasks.toml -F template -- BLARG
template:
  commands:
    echo BLARG
```

closes https://github.com/notnmeyer/tsk/issues/85