### PR TITLE
feat: add fish shell completions

### DIFF
--- a/completions/tsk.fish
+++ b/completions/tsk.fish
@@ -1,0 +1,18 @@
+function __fish_tsk_list_tasks
+    # take the task name and the first line in the description and format them:
+    # <name>TAB<desc>
+    command tsk -l --output toml 2>/dev/null \
+        | tomlq -r '
+            to_entries[]
+            | [ .key, (
+                .value.description // ""
+                | split("\n")[0]
+              ) ]
+            | @tsv
+          '
+end
+
+complete \
+    -c tsk \
+    -f \
+    -a '(__fish_tsk_list_tasks)'

--- a/tasks.toml
+++ b/tasks.toml
@@ -57,3 +57,9 @@ cmds = [
   "gon gon-arm64.hcl",
   "gon gon-amd64.hcl",
 ]
+
+[tasks.install_completions]
+description = "install shell completions"
+cmds = [
+  "cp completions/tsk.fish ~/.config/fish/completions/"
+]


### PR DESCRIPTION
enables tab-completion of task names in fish,

<img width="776" alt="image" src="https://github.com/user-attachments/assets/03b54b7c-9c88-40d2-a781-706cdceb6527" />

hacked together right now, requires `yq` to be installed (for the `tomlq` binary). will make things less tacky after https://github.com/notnmeyer/tsk/issues/93 and https://github.com/notnmeyer/tsk/issues/95

`tsk install_completions` to install it right now. ultimately the brew package should take of this.