### PR TITLE
feat: json output format

### DIFF
--- a/internal/outputformat/outputformat.go
+++ b/internal/outputformat/outputformat.go
@@ -7,18 +7,19 @@ import (
 type OutputFormat string
 
 const (
+	JSON     OutputFormat = "json"
 	Markdown OutputFormat = "md"
 	Text     OutputFormat = "text"
 	TOML     OutputFormat = "toml"
 )
 
 func String() string {
-	return fmt.Sprintf("%s, %s, %s", string(Markdown), string(Text), string(TOML))
+	return fmt.Sprintf("%s, %s, %s, %s", string(JSON), string(Markdown), string(Text), string(TOML))
 }
 
 func IsValid(format string) bool {
 	switch format {
-	case string(Markdown), string(Text), string(TOML):
+	case string(JSON), string(Markdown), string(Text), string(TOML):
 		return true
 	}
 	return false

--- a/internal/outputformat/outputformat_test.go
+++ b/internal/outputformat/outputformat_test.go
@@ -5,7 +5,17 @@ import (
 )
 
 func TestIsValid(t *testing.T) {
-	want, got := true, IsValid("toml")
+	want, got := true, IsValid("json")
+	if want != got {
+		t.Errorf("got %t, wanted %t\n", got, want)
+	}
+
+	want, got = true, IsValid("md")
+	if want != got {
+		t.Errorf("got %t, wanted %t\n", got, want)
+	}
+
+	want, got = true, IsValid("toml")
 	if want != got {
 		t.Errorf("got %t, wanted %t\n", got, want)
 	}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -184,6 +185,8 @@ func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp, format output.
 	indent := "  "
 
 	switch format {
+	case output.JSON:
+		json.NewEncoder(os.Stdout).Encode(tasks)
 	case output.Markdown:
 		for name, t := range tasks {
 			fmt.Printf("## %s\n", name)


### PR DESCRIPTION
closes https://github.com/notnmeyer/tsk/issues/95

```
➜ tsk --list --output=json | jq .
{
  "build": {
    "Cmds": [
      "go build -o bin/tsk -v cmd/tsk/tsk.go"
    ],
    "Deps": null,
    "Description": "",
    "Dir": "",
    "Env": null,
    "DotEnv": "",
    "Pure": false
  },...
}
```