### PR TITLE
feat: short desc field

### DIFF
--- a/completions/tsk.fish
+++ b/completions/tsk.fish
@@ -1,8 +1,6 @@
 function __fish_tsk_list_tasks
-    # take the task name and the first line in the description and format them:
-    # <name>TAB<desc>
-    command /Users/nate/code/tsk/bin/tsk -l --output json 2>/dev/null \
-        | jq -r 'to_entries[] | [.key, .value.Desc] | @tsv'
+    # take the task name and the first line in the description and format them: <name>TAB<desc>
+    command tsk -l --output json 2>/dev/null | jq -r 'to_entries[] | [.key, .value.Desc] | @tsv'
 end
 
 complete \

--- a/completions/tsk.fish
+++ b/completions/tsk.fish
@@ -1,15 +1,8 @@
 function __fish_tsk_list_tasks
     # take the task name and the first line in the description and format them:
     # <name>TAB<desc>
-    command tsk -l --output toml 2>/dev/null \
-        | tomlq -r '
-            to_entries[]
-            | [ .key, (
-                .value.description // ""
-                | split("\n")[0]
-              ) ]
-            | @tsv
-          '
+    command /Users/nate/code/tsk/bin/tsk -l --output json 2>/dev/null \
+        | jq -r 'to_entries[] | [.key, .value.Desc] | @tsv'
 end
 
 complete \

--- a/examples/tasks.toml
+++ b/examples/tasks.toml
@@ -98,3 +98,12 @@ cmds = ["echo exiting 1...", "exit 1"]
 [tasks.non_existent_dep]
 deps = [["non-existent-task"]]
 cmds = ["echo 'running cmd...'"]
+
+[tasks.desc]
+desc = "this is a short desc"
+description = '''
+  this is a multi-line
+  description blah blah blah
+  blah blah blah
+'''
+cmds = ["echo desc"]

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -34,6 +34,7 @@ type Config struct {
 type Task struct {
 	Cmds        []string          `toml:"cmds"`
 	Deps        [][]string        `toml:"deps"`
+	Desc        string            `toml:"desc"`
 	Description string            `toml:"description"`
 	Dir         string            `toml:"dir"`
 	Env         map[string]string `toml:"env"`
@@ -209,6 +210,15 @@ func (exec *Executor) ListTasksFromTaskFile(regex *regexp.Regexp, format output.
 			if t.Description != "" {
 				fmt.Printf("%sdescription:\n", indent)
 				trimmed := strings.TrimSpace(t.Description)
+				for _, line := range strings.Split(trimmed, "\n") {
+					fmt.Printf("%s%s\n", strings.Repeat(indent, 2), line)
+				}
+			}
+
+			// desc
+			if t.Desc != "" {
+				fmt.Printf("%sdesc:\n", indent)
+				trimmed := strings.TrimSpace(t.Desc)
 				for _, line := range strings.Split(trimmed, "\n") {
 					fmt.Printf("%s%s\n", strings.Repeat(indent, 2), line)
 				}

--- a/tasks.toml
+++ b/tasks.toml
@@ -11,7 +11,7 @@ cmds = [
 ]
 
 [tasks.clean]
-desc = "rm build artifacts"
+desc = "Remove build artifacts"
 cmds = [
   "rm -rf ./dist/*"
 ]
@@ -61,7 +61,7 @@ cmds = [
 ]
 
 [tasks.install_completions]
-desc = "install shell completions"
+desc = "Install shell completions"
 cmds = [
   "cp completions/tsk.fish ~/.config/fish/completions/"
 ]

--- a/tasks.toml
+++ b/tasks.toml
@@ -1,30 +1,27 @@
 [tasks.run]
+desc = "Run tsk"
 cmds = [
   "go run cmd/tsk/tsk.go {{.CLI_ARGS}}"
 ]
+
 [tasks.build]
+desc = "Build the project"
 cmds = [
   "go build -o bin/tsk -v cmd/tsk/tsk.go"
 ]
 
 [tasks.clean]
+desc = "rm build artifacts"
 cmds = [
   "rm -rf ./dist/*"
 ]
 
 [tasks.release]
-description = '''
-Create a release (locally, no CI).
-
-usage: version=0.0.0 tsk release
-'''
-dotenv = ".env"
-
-[tasks.release_ci]
+desc = "Trigger a release"
 description = '''
 Create and push a new tag to GitHub, triggering a new release from CI.
 
-usage: `tsk release_ci -- v0.0.0`
+usage: `tsk release -- v0.0.0`
 '''
 cmds = [
   "git tag {{.CLI_ARGS}}",
@@ -32,19 +29,23 @@ cmds = [
 ]
 
 [tasks.release_dry]
+desc = "goreleaser dry run"
 dotenv = ".env"
 cmds = [
   "goreleaser release --clean --skip-publish --skip-validate"
 ]
 
 [tasks.test]
+desc = "Run tests"
 cmds = ["go test ./... {{.CLI_ARGS}}"]
 
 [tasks.deps]
+desc = "Install deps"
 cmds = ["go mod tidy"]
 
 [tasks.install_release]
 # see scripts/install_release.sh for configurable env arguments
+desc = "Install a tsk version"
 description = '''
 Downloads the specified release and installs it to ~/bin.
 
@@ -52,6 +53,7 @@ usage: version=0.8.1 platform=Darwin arch=arm64 tsk install_release
 '''
 
 [tasks.sign]
+desc = "Sign binaries"
 dotenv = ".env"
 cmds = [
   "gon gon-arm64.hcl",
@@ -59,7 +61,7 @@ cmds = [
 ]
 
 [tasks.install_completions]
-description = "install shell completions"
+desc = "install shell completions"
 cmds = [
   "cp completions/tsk.fish ~/.config/fish/completions/"
 ]


### PR DESCRIPTION
closes https://github.com/notnmeyer/tsk/issues/93

adds a `desc` field that is functionally the same as `description` but as the name (probably doesn't) imply, its for short form, single-line, descriptions. having a field for this makes sense when you want something brief for completions, but still allows more exhaustive stuff in `descriptions`.

there's no validation preventing you from adding a bunch of text to `desc` and wrecking the completion output. very exciting.

also updates the completion script to use jq (because json output is now support) and uses the "desc" field for completion descriptions.